### PR TITLE
Fix AuthErrorHandler behavior and improve validation logic

### DIFF
--- a/custom_validation_error_test.go
+++ b/custom_validation_error_test.go
@@ -255,3 +255,44 @@ func TestValidationErrorHandlerImpliesValidationEnabled(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, fiber.StatusOK, resp.StatusCode, "OpenAPI docs should be enabled by default when only ValidationErrorHandler is configured")
 }
+
+// TestAuthErrorHandlerOnlyDoesNotDisableDefaults verifies that setting only AuthErrorHandler
+// does not accidentally disable EnableValidation or EnableOpenAPIDocs (both default to true).
+func TestAuthErrorHandlerOnlyDoesNotDisableDefaults(t *testing.T) {
+	app := fiber.New()
+
+	oapi := New(app, Config{
+		AuthErrorHandler: func(c *fiber.Ctx, err *AuthError) error {
+			return c.Status(err.StatusCode).JSON(fiber.Map{"custom": true})
+		},
+	})
+
+	type TestInput struct {
+		Name string `json:"name" validate:"required"`
+	}
+	type TestOutput struct {
+		Message string `json:"message"`
+	}
+
+	Post[TestInput, TestOutput, struct{}](
+		oapi,
+		"/test",
+		func(c *fiber.Ctx, input TestInput) (TestOutput, struct{}) {
+			return TestOutput{Message: "ok"}, struct{}{}
+		},
+		OpenAPIOptions{},
+	)
+
+	// Validation should still be enabled (default true)
+	req := httptest.NewRequest("POST", "/test", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode, "Validation should be enabled when only AuthErrorHandler is configured")
+
+	// OpenAPI docs should still be enabled (default true)
+	req = httptest.NewRequest("GET", "/docs", nil)
+	resp, err = app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, fiber.StatusOK, resp.StatusCode, "OpenAPI docs should be enabled when only AuthErrorHandler is configured")
+}

--- a/fiberoapi.go
+++ b/fiberoapi.go
@@ -52,8 +52,8 @@ func New(app *fiber.App, config ...Config) *OApiApp {
 		}
 		// If no explicit config, keep the defaults (true, true, false)
 
-		// Special case: if ValidationErrorHandler is set and boolean fields seem to be using zero values,
-		// restore defaults since it makes no sense to have a validation error handler without validation
+		// Special case: if only handler(s) are set and boolean fields seem to be using zero values,
+		// restore defaults since it makes no sense to have error handlers without validation/docs
 		otherExplicitConfig := provided.EnableAuthorization ||
 			provided.AuthService != nil ||
 			provided.SecuritySchemes != nil ||
@@ -63,9 +63,10 @@ func New(app *fiber.App, config ...Config) *OApiApp {
 
 		// Only restore defaults if ALL boolean fields are false (suggesting they weren't explicitly set)
 		allBooleansAreFalse := !provided.EnableValidation && !provided.EnableOpenAPIDocs && !provided.EnableAuthorization
+		hasOnlyHandlers := (provided.ValidationErrorHandler != nil || provided.AuthErrorHandler != nil) && !otherExplicitConfig
 
-		if provided.ValidationErrorHandler != nil && !otherExplicitConfig && allBooleansAreFalse {
-			// ValidationErrorHandler is the only explicit config, so restore defaults for boolean fields
+		if hasOnlyHandlers && allBooleansAreFalse {
+			// Only handler(s) are set, so restore defaults for boolean fields
 			cfg.EnableValidation = true   // Keep validation enabled - the handler needs it
 			cfg.EnableOpenAPIDocs = true  // Keep docs enabled - default behavior
 		}

--- a/fiberoapi.go
+++ b/fiberoapi.go
@@ -52,8 +52,8 @@ func New(app *fiber.App, config ...Config) *OApiApp {
 		}
 		// If no explicit config, keep the defaults (true, true, false)
 
-		// Special case: if only handler(s) are set and boolean fields seem to be using zero values,
-		// restore defaults since it makes no sense to have error handlers without validation/docs
+		// Heuristic: when only handler(s) are provided and all booleans are at zero value,
+		// assume the caller didn't intend to disable validation/docs — restore defaults.
 		otherExplicitConfig := provided.EnableAuthorization ||
 			provided.AuthService != nil ||
 			provided.SecuritySchemes != nil ||

--- a/types.go
+++ b/types.go
@@ -73,7 +73,7 @@ type Config struct {
 	SecuritySchemes        map[string]SecurityScheme // OpenAPI security schemes
 	DefaultSecurity        []map[string][]string     // Default security requirements
 	ValidationErrorHandler ValidationErrorHandler    // Custom handler for validation errors
-	AuthErrorHandler       AuthErrorHandler           // Custom handler for auth errors (401/403/5xx)
+	AuthErrorHandler       AuthErrorHandler          // Custom handler for auth errors (401/403/5xx)
 }
 
 // OpenAPIOptions represents options for OpenAPI operations

--- a/types.go
+++ b/types.go
@@ -73,7 +73,7 @@ type Config struct {
 	SecuritySchemes        map[string]SecurityScheme // OpenAPI security schemes
 	DefaultSecurity        []map[string][]string     // Default security requirements
 	ValidationErrorHandler ValidationErrorHandler    // Custom handler for validation errors
-	AuthErrorHandler       AuthErrorHandler           // Custom handler for auth errors (401/403)
+	AuthErrorHandler       AuthErrorHandler           // Custom handler for auth errors (401/403/5xx)
 }
 
 // OpenAPIOptions represents options for OpenAPI operations


### PR DESCRIPTION
Ensure that the AuthErrorHandler does not disable validation or OpenAPI documentation when set alone. Update the logic for restoring defaults in the New function to account for cases where only error handlers are configured. Additionally, clarify the AuthErrorHandler comment to include 5xx errors in its configuration.