### PR TITLE
Fix OpenAPI schema to render time.Time in date-time format

### DIFF
--- a/fiberoapi.go
+++ b/fiberoapi.go
@@ -375,6 +375,11 @@ func collectAllTypes(t reflect.Type, collected map[string]reflect.Type) {
 	// Handle pointers
 	t = dereferenceType(t)
 
+	// time.Time is rendered inline as a date-time string, not as a component schema
+	if isTimeType(t) {
+		return
+	}
+
 	typeName := getTypeName(t)
 	if typeName == "" {
 		return
@@ -571,6 +576,11 @@ func getSimpleTypeName(t reflect.Type) string {
 	}
 }
 
+// isTimeType reports whether t is the standard library time.Time type.
+func isTimeType(t reflect.Type) bool {
+	return t != nil && t.Kind() == reflect.Struct && t.Name() == "Time" && t.PkgPath() == "time"
+}
+
 // generateSchema generates an OpenAPI schema from a Go type
 func generateSchema(t reflect.Type) map[string]interface{} {
 	if t == nil {
@@ -581,6 +591,14 @@ func generateSchema(t reflect.Type) map[string]interface{} {
 
 	// Handle pointers
 	t = dereferenceType(t)
+
+	if isTimeType(t) {
+		return map[string]interface{}{
+			"type":    "string",
+			"format":  "date-time",
+			"example": "2006-01-02T15:04:05Z",
+		}
+	}
 
 	schema := make(map[string]interface{})
 
@@ -706,6 +724,13 @@ func generateFieldSchema(t reflect.Type) map[string]interface{} {
 
 	// Handle pointers
 	t = dereferenceType(t)
+
+	if isTimeType(t) {
+		schema["type"] = "string"
+		schema["format"] = "date-time"
+		schema["example"] = "2006-01-02T15:04:05Z"
+		return schema
+	}
 
 	switch t.Kind() {
 	case reflect.String:

--- a/time_type_test.go
+++ b/time_type_test.go
@@ -1,0 +1,121 @@
+package fiberoapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type Workspace struct {
+	WorkspaceID string    `json:"workspace_id"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type WorkspaceResponse struct {
+	Workspaces []Workspace `json:"workspaces"`
+}
+
+type EmptyRequest struct{}
+
+func TestTimeTypeRendersAsDateTimeString(t *testing.T) {
+	app := fiber.New()
+	oapi := New(app)
+
+	Post(oapi, "/workspaces", func(c *fiber.Ctx, req *EmptyRequest) (*WorkspaceResponse, *ErrorResponse) {
+		return &WorkspaceResponse{}, nil
+	}, OpenAPIOptions{
+		OperationID: "listWorkspaces",
+		Tags:        []string{"workspaces"},
+	})
+
+	oapi.SetupDocs()
+
+	req := httptest.NewRequest("GET", "/openapi.json", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var spec map[string]interface{}
+	if err := json.Unmarshal(body, &spec); err != nil {
+		t.Fatalf("Failed to parse OpenAPI JSON: %v", err)
+	}
+
+	components := spec["components"].(map[string]interface{})
+	schemas := components["schemas"].(map[string]interface{})
+
+	if _, exists := schemas["Time"]; exists {
+		t.Errorf("time.Time should not be registered as a 'Time' component schema")
+	}
+
+	workspaceSchema, ok := schemas["Workspace"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected Workspace schema to be present")
+	}
+	props := workspaceSchema["properties"].(map[string]interface{})
+
+	for _, field := range []string{"created_at", "updated_at"} {
+		f, ok := props[field].(map[string]interface{})
+		if !ok {
+			t.Fatalf("Expected Workspace.%s to be an object", field)
+		}
+		if f["type"] != "string" {
+			t.Errorf("Expected %s.type to be 'string', got %v", field, f["type"])
+		}
+		if f["format"] != "date-time" {
+			t.Errorf("Expected %s.format to be 'date-time', got %v", field, f["format"])
+		}
+		if _, hasRef := f["$ref"]; hasRef {
+			t.Errorf("Expected %s to be inlined, not a $ref", field)
+		}
+	}
+}
+
+type EventWithPointerTime struct {
+	Name      string     `json:"name"`
+	StartedAt *time.Time `json:"started_at,omitempty"`
+}
+
+func TestPointerTimeTypeRendersAsDateTimeString(t *testing.T) {
+	app := fiber.New()
+	oapi := New(app)
+
+	Post(oapi, "/events", func(c *fiber.Ctx, req *EmptyRequest) (*EventWithPointerTime, *ErrorResponse) {
+		return &EventWithPointerTime{}, nil
+	}, OpenAPIOptions{
+		OperationID: "createEvent",
+		Tags:        []string{"events"},
+	})
+
+	oapi.SetupDocs()
+
+	req := httptest.NewRequest("GET", "/openapi.json", nil)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var spec map[string]interface{}
+	if err := json.Unmarshal(body, &spec); err != nil {
+		t.Fatalf("Failed to parse OpenAPI JSON: %v", err)
+	}
+
+	schemas := spec["components"].(map[string]interface{})["schemas"].(map[string]interface{})
+	eventSchema := schemas["EventWithPointerTime"].(map[string]interface{})
+	props := eventSchema["properties"].(map[string]interface{})
+
+	startedAt, ok := props["started_at"].(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected started_at property to be present")
+	}
+	if startedAt["type"] != "string" || startedAt["format"] != "date-time" {
+		t.Errorf("Expected *time.Time to render as string/date-time, got %v", startedAt)
+	}
+}


### PR DESCRIPTION
This pull request improves how the OpenAPI schema generator handles Go's `time.Time` type. Now, `time.Time` fields are rendered inline as `"type": "string", "format": "date-time"` instead of being registered as a separate schema component. This ensures that date-time fields are correctly described in generated OpenAPI specs, and avoids unnecessary component definitions. Comprehensive tests are added to verify this behavior for both direct and pointer uses of `time.Time`.

**OpenAPI schema generation improvements:**

* Added logic in `collectAllTypes`, `generateSchema`, and `generateFieldSchema` in `fiberoapi.go` to detect `time.Time` and render it inline as a string with `date-time` format, rather than as a component schema. [[1]](diffhunk://#diff-873cff63a05f2e14b5167d057de0e891026b7946cdc1838f89eb190f841194c7R378-R382) [[2]](diffhunk://#diff-873cff63a05f2e14b5167d057de0e891026b7946cdc1838f89eb190f841194c7R595-R602) [[3]](diffhunk://#diff-873cff63a05f2e14b5167d057de0e891026b7946cdc1838f89eb190f841194c7R728-R734)
* Introduced the helper function `isTimeType` to reliably detect the `time.Time` type.

**Testing enhancements:**

* Added `time_type_test.go` with tests to ensure `time.Time` and `*time.Time` fields are rendered as `"type": "string", "format": "date-time"` and are not registered as component schemas in the OpenAPI output.